### PR TITLE
Made fromJValue work.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,3 +20,6 @@ addSbtPlugin("com.gu" % "sbt-version-info-plugin" % "2.8")
 addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.5.0")
 
 addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.9.0")
+
+addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.6.0")
+

--- a/src/main/scala/com/demo/Foo.scala
+++ b/src/main/scala/com/demo/Foo.scala
@@ -1,12 +1,16 @@
 package com.demo
 
 
+import net.liftweb.json.JValue
+import net.liftweb.json.JsonAST.{JNull, JNothing, JField, JValue}
 import net.liftweb.json._
 import net.liftweb._
 import net.liftweb.common._
 import net.liftweb.mongodb.ObjectIdSerializer
 import net.liftweb.mongodb.record._
 import net.liftweb.mongodb.record.field._
+import net.liftweb.record.FieldHelpers
+import net.liftweb.record.FieldHelpers._
 import net.liftweb.record.field._
 import org.bson.types._
 import com.foursquare.index._
@@ -26,8 +30,37 @@ class Foo extends MongoRecord[Foo] with ObjectIdPk[Foo] with IndexedRecord[Foo] 
   def idAsString: String = id.toString
 
   object idRef extends ObjectIdField(this)
-  object idRefList1 extends ObjectIdRefListField(this, Bar)
-  object idRefList2 extends ObjectIdRefListField(this, Bar)
+  object idRefList1 extends ObjectIdRefListField(this, Bar) {
+    override def setFromJValue(jvalue: JValue) = jvalue match {
+      case JNothing|JNull if optional_? => setBox(Empty)
+      case JArray(arr) =>
+        println("set from is arr: "+arr)
+        setBox(Full(arr.map {
+          case JObject(JField("$oid", JString(s)) :: Nil) if (ObjectId.isValid(s)) => new ObjectId(s)
+          case _ => throw new IllegalArgumentException()
+        }))
+      case other =>
+        println("set from other")
+        setBox(FieldHelpers.expectedA("JArray", other))
+    }
+
+  }
+  object idRefList2 extends ObjectIdRefListField(this, Bar) {
+
+    override def setFromJValue(jvalue: JValue) = jvalue match {
+      case JNothing|JNull if optional_? => setBox(Empty)
+      case JArray(arr) =>
+        println("set from is arr: "+arr)
+        setBox(Full(arr.map {
+          case JObject(JField("$oid", JString(s)) :: Nil) if (ObjectId.isValid(s)) => new ObjectId(s)
+          case _ => throw new IllegalArgumentException()
+        }))
+      case other =>
+        println("set from other")
+        setBox(FieldHelpers.expectedA("JArray", other))
+    }
+
+  }
 
 }
 
@@ -37,44 +70,76 @@ object Foo extends Foo with MongoMetaRecord[Foo] with Loggable {
   override def formats = DefaultFormats + new ObjectIdSerializer
   override def collectionName = "foos"
 
+  /** Create a record by decoding a JValue which must be a JObject */
+  override def fromJValue(jvalue: JValue): Box[Foo] = {
+    val inst = createRecord
+    setFieldsFromJValue(inst, jvalue) map (_ => inst)
+  }
+
+  /** Attempt to decode a JValue, which must be a JObject, into a record instance */
+  override def setFieldsFromJValue(rec: Foo, jvalue: JValue): Box[Unit] = {
+    def fromJFields(jfields: List[JField]): Box[Unit] = {
+      for {
+        jfield <- jfields
+        field <- rec.fieldByName(jfield.name)
+      } {
+        println(s"Set field ${field.name}(${field.getClass.getName}}): "+pretty(render(jfield.value)))
+        field.setFromJValue(jfield.value)
+      }
+
+      Full(())
+    }
+
+    jvalue match {
+      case JObject(jfields) =>
+        println("jobject")
+        fromJFields(jfields)
+      case other =>
+        println("other")
+        expectedA("JObject", other)
+    }
+  }
+
   def apply(in: JValue): Box[Foo] = {
 
     // Logs JSON passed to RestHelper
     logger.info(s"json before transform:${pretty(render(in))}")
 
     // Transforms JSON passed to RestHelper
-    val newJson = in transform {
-      case JField("idRefList1", JArray(idList)) => {
-        val objectIds = idList.collect {
-          case JString(id) => JObject(List(JField("$oid", id)))
-        }
-        JField("idRefList1", JArray(objectIds))
-      }
-      case JField("idRefList2", JArray(objectIdStrings)) => {
-        val objectIds = objectIdStrings.collect {
-          case JString(id) => JObject(List(JField("$oid", id)))
-        }
-        JField("idRefList2", JArray(objectIds))
-      }
-    }
+//    val newJson = in transform {
+//      case JField("idRefList1", JArray(idList)) => {
+//        val objectIds = idList.collect {
+//          case JString(id) => JObject(List(JField("$oid", id)))
+//        }
+//        JField("idRefList1", JArray(objectIds))
+//      }
+//      case JField("idRefList2", JArray(objectIdStrings)) => {
+//        val objectIds = objectIdStrings.collect {
+//          case JString(id) => JObject(List(JField("$oid", id)))
+//        }
+//        JField("idRefList2", JArray(objectIds))
+//      }
+//    }
 
     for {
       foo1 <- Full(Foo.createRecord.idRefList1(List(new ObjectId(),new ObjectId())).idRefList2(List(new ObjectId(),new ObjectId())))
       foo2 <- Foo.fromJValue(in)
-      foo3 <- Foo.fromJValue(newJson)
+//      foo3 <- Foo.fromJValue(newJson)
     } yield {
       foo1.idRefList1.get.map(id => logger.info(s"foo.idList1.get.map class:${id.getClass}"))
 
+      println("FOO2 IS "+foo2.idRefList1)
+
       //Below causes java.lang.ClassCastException: java.lang.String cannot be cast to org.bson.types.ObjectId
-      //foo2.idList1.get.map(id => logger.info(s"foo2.idList1.get.map class:${id.isInstanceOf[ObjectId]}"))
+      foo2.idRefList1.get.map(id => logger.info(s"foo2.idRefList1.get.map class:${id.isInstanceOf[ObjectId]}"))
       //foo3.idList1.get.map(id => logger.info(s"foo2.idList1.get.map class:${id.isInstanceOf[ObjectId]}"))
 
       logger.info(s"Foo.createRecord:${foo1}")
       logger.info(s"Deserialization of json from API (without transformation):${foo2}")
-      logger.info(s"Deserialization after transform:${foo3}")
+//      logger.info(s"Deserialization after transform:${foo3}")
     }
 
-    logger.info(s"json after transform:${pretty(render(newJson))}")
+//    logger.info(s"json after transform:${pretty(render(newJson))}")
 
     // When ObjectIdRefListField is serialized Lift produces a List[String].
     // I was expecting fromJValue to realize that the field it was deserializing


### PR DESCRIPTION
I did some serious overriding of the json parsing for ObjectIds.

I'm not sure why this was necessary and why the original code didn't parse the JValue.

The curl URL with which it's working is:

```
curl -i -HAccept:application/json -HContet-type:application/json -d'{ "idRefList1":   [{"$oid":"5449c9e4d4c6a72dc51949ff"}], "idRefList2": [{"$oid":"5449cadfd4c6df9b3348f691"}], "idRef": {"$oid":"54485112d4c6164eb9412dd0"} }' -XPUT http://localhost:8080/foos
```

Changing the override code you can change the format of the ObjectId accepting Strings (without the $oid   part) as well.

It does seem as if the fromJValue parsing does not go through the lift-json stuff for deserialization.
